### PR TITLE
Add PlatformIO custom component

### DIFF
--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -84,7 +84,11 @@ cloud:
 
 group: !include groups.yaml
 automation: !include automations.yaml
-script: !include scripts.yaml
+#script: !include scripts.yaml
+script:
+  build_esp:
+    sequence:
+      - service: platformio.build
 
 mqtt:
   broker: mqtt
@@ -100,3 +104,25 @@ mqtt:
 
 recorder:
   db_url: postgresql://homeassistant@ha_db/homeassistant?sslmode=require&sslcert=/run/secrets/ha_cert&sslkey=/run/secrets/ha_key&sslrootcert=/run/secrets/ca
+
+input_text:
+  id:
+    name: Device Id
+  ssid:
+    name: SSID
+  wifi_password:
+    name: Wifi Password
+    mode: password
+  ssl_fingerprint:
+    name: SSL Fingerprint
+  mqtt_host:
+    name: MQTT Host
+
+input_boolean:
+  create_homie:
+    name: Turn on to provision a new homie device.
+    initial: off
+    icon: mdi:chip
+
+platformio:
+  #topic: platformio/build/nodemcuv2

--- a/config/custom_components/platformio.py
+++ b/config/custom_components/platformio.py
@@ -72,19 +72,18 @@ def setup(hass, config):
             "mqtt": {
                 "auth": True,
                 "host": mqtt_host,
-                "port": 8883,
+                "port": 1883,
                 "base_topic": "hals/",
                 "username": "$mqtt_username",
                 "password": "$mqtt_password",
-                "ssl": True,
+                "ssl": False,
                 "ssl_fingerprint": ssl_fingerprint 
             },
             "ota": {
                 "enabled": False
             },
             "settings": {
-                "dht22_pin": 2,
-                "percentage": 55
+                "dht22_pin": 4
             }
         }
         mqtt.publish("platformio/build/nodemcuv2", json.dumps(hal_config, sort_keys=True))

--- a/config/custom_components/platformio.py
+++ b/config/custom_components/platformio.py
@@ -83,6 +83,7 @@ def setup(hass, config):
                 "enabled": False
             },
             "settings": {
+                "dht22_pin": 2,
                 "percentage": 55
             }
         }


### PR DESCRIPTION
I wanted a way to kick off building and flashing ESP8266 firmware from within Home Assistant. My solution was to hook the PlatformIO image up to the MQTT network and listen on platformio/build/+ for build/flash commands. The + should be the env of the firmware to build (nodemcu2 for example), and the payload should be the json config file that Homie uses for its settings. Obviously this is only the Home Assistant side of the equation. 

This is still a very rough outline of what needs to happened and could stand to be cleaned up and refactored. 